### PR TITLE
Add ExpectedStatusCode into MonitorExternalHTTP

### DIFF
--- a/monitors.go
+++ b/monitors.go
@@ -66,6 +66,7 @@ import (
       "responseTimeDuration": 5,
       "certificationExpirationCritical": 15,
       "certificationExpirationWarning": 30,
+      "expectedStatusCode": 200,
       "requestBody": "Request Body",
       "containsString": "Example",
       "skipCertificateVerification": true,
@@ -243,6 +244,7 @@ type MonitorExternalHTTP struct {
 	CertificationExpirationWarning  *uint64  `json:"certificationExpirationWarning,omitempty"`
 	SkipCertificateVerification     bool     `json:"skipCertificateVerification,omitempty"`
 	FollowRedirect                  bool     `json:"followRedirect,omitempty"`
+	ExpectedStatusCode              *int     `json:"expectedStatusCode,omitempty"`
 	// Empty list of headers and nil are different. You have to specify empty
 	// list as headers explicitly if you want to remove all headers instead of
 	// using nil.

--- a/monitors_test.go
+++ b/monitors_test.go
@@ -54,6 +54,7 @@ func TestFindMonitors(t *testing.T) {
 					"containsString":                  "Foo Bar Baz",
 					"skipCertificateVerification":     true,
 					"followRedirect":                  true,
+					"expectedStatusCode":              200,
 					"headers": []map[string]interface{}{
 						{"name": "Cache-Control", "value": "no-cache"},
 					},
@@ -161,6 +162,10 @@ func TestFindMonitors(t *testing.T) {
 
 		if m.FollowRedirect != true {
 			t.Error("request sends json including followRedirect but: ", m)
+		}
+
+		if *m.ExpectedStatusCode != 200 {
+			t.Error("request sends json including expectedStatusCode but: ", m)
 		}
 
 		if !reflect.DeepEqual(m.Headers, []HeaderField{{Name: "Cache-Control", Value: "no-cache"}}) {


### PR DESCRIPTION
Hi!

This PR adds support for `expectedStatusCode` in the external monitor API.

See also [外形監視でOKと判定するHTTPステータスコードを選択可能にしました
](https://mackerel.io/ja/blog/entry/weekly/20241203#%E5%A4%96%E5%BD%A2%E7%9B%A3%E8%A6%96%E3%81%A7OK%E3%81%A8%E5%88%A4%E5%AE%9A%E3%81%99%E3%82%8BHTTP%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%B3%E3%83%BC%E3%83%89%E3%82%92%E9%81%B8%E6%8A%9E%E5%8F%AF%E8%83%BD%E3%81%AB%E3%81%97%E3%81%BE%E3%81%97%E3%81%9F)
